### PR TITLE
Expand case records and clean print layout

### DIFF
--- a/casekit/case-01/police-records.html
+++ b/casekit/case-01/police-records.html
@@ -28,15 +28,15 @@
 
 <section class='mt-2'>
 <h2>Summary</h2>
-<p>On 2023-11-06 at approximately 21:13 hours, patrol units responded to a disturbance at 12 Maple St. Upon entry, officers located Lena Roussel unresponsive. The accused Nathan Clarke was not on scene. Initial observations noted signs of struggle and a silver locket near the body.</p>
+<p>On 2023-11-06 at approximately 21:13 hours, patrol units responded to a disturbance at 12 Maple St. Upon entry, officers located Lena Roussel unresponsive. The accused Nathan Clarke was not on scene. Initial observations noted signs of struggle, an overturned chair, and a silver locket near the body. The living room contained a broken picture frame and scattered mail suggesting a hurried search. Neighbors mentioned hearing the victim arguing with an unidentified caller roughly thirty minutes prior.</p>
 </section>
 <section class='mt-2'>
 <h2>Timeline</h2>
 <table class='table'><thead><tr><th>Time</th><th>Event</th><th>Ref</th></tr></thead><tbody><tr><td>21:13</td><td>911 call from neighbor reports disturbance</td><td>CR-LOG-01</td></tr><tr><td>21:40</td><td>Units arrive at 12 Maple St</td><td>IR-01-001</td></tr><tr><td>21:45</td><td>Victim Lena Roussel found deceased</td><td>E-Log-01</td></tr></tbody></table>
 </section>
-<section class='mt-2 page-break'>
+<section class='mt-2'>
 <h2>Officer Notes</h2>
-<p>Scene secured at 21:40. Weather clear, 5°C. Suspect vehicle not observed. A burner phone later linked to Nathan Clarke was recovered but records show no outgoing calls during critical window.</p>
+<p>Scene secured at 21:40. Weather clear, 5°C. Suspect vehicle not observed. A burner phone later linked to Nathan Clarke was recovered but records show no outgoing calls during critical window. Noted faint smell of bleach in kitchen, and a cup of coffee remained half full on the table. Officers canvassed alleyway behind residence and located fresh shoe prints leading toward Maple Street.</p>
 </section>
 <section class='mt-2'>
 <h2>Supplemental</h2>
@@ -45,10 +45,8 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>EVIDENCE LOG</h1>
@@ -73,10 +71,9 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
+
 <article class='doc'>
 <section class='doc-header'>
 <h1>WITNESS STATEMENTS</h1>
@@ -96,21 +93,19 @@
 
 <section class='mt-2'>
 <h2>Statement: Neighbor</h2>
-<p>I, Jenna Lee, residing at 12 Maple St Unit 2, state that around 21:10 I heard loud voices from Unit 1 followed by a thud. I saw a woman with dark hair hurriedly exit the building. She carried what looked like a tote bag.</p>
+<p>I, Jenna Lee, residing at 12 Maple St Unit 2, state that around 21:10 I heard loud voices from Unit 1 followed by a thud. I saw a woman with dark hair hurriedly exit the building. She carried what looked like a tote bag. I went back inside and continued watching television but kept the chain on the door.</p>
 <div class='sig-line'></div>
 </section>
-<section class='mt-2 page-break'>
+<section class='mt-2'>
 <h2>Statement: Accused</h2>
-<p>I, Nathan Clarke, state that I was at work until 22:30. My phone was left at home. I deny any involvement in the death of Lena Roussel. Marina Hale had been calling me repeatedly in the past weeks.</p>
+<p>I, Nathan Clarke, state that I was at work until 22:30. My phone was left at home. I deny any involvement in the death of Lena Roussel. Marina Hale had been calling me repeatedly in the past weeks. After my shift I stopped for coffee and chatted with the cashier about hockey scores before heading home.</p>
 <div class='sig-line'></div>
 </section>
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>INTERVIEW TRANSCRIPT</h1>
@@ -130,19 +125,17 @@
 
 <section class='mt-2'>
 <h2>Interview of Nathan Clarke</h2>
-<p><strong>Q:</strong> Where were you on 2023-11-06?<br><strong>A:</strong> I was covering shift at diner until 22:30.</p><p><strong>Q:</strong> Do you know Lena Roussel?<br><strong>A:</strong> She was a friend of Marina Hale.</p><p><strong>Q:</strong> Why was your locket at scene?<br><strong>A:</strong> I lost it weeks ago.</p>
+<p><strong>Q:</strong> Where were you on 2023-11-06?<br><strong>A:</strong> I was covering shift at diner until 22:30.</p><p><strong>Q:</strong> Do you know Lena Roussel?<br><strong>A:</strong> She was a friend of Marina Hale.</p><p><strong>Q:</strong> Why was your locket at scene?<br><strong>A:</strong> I lost it weeks ago.</p><p><strong>Q:</strong> Did you visit Lena earlier that day?<br><strong>A:</strong> No, I stayed at the diner all afternoon.</p><p><strong>Q:</strong> What route do you take home from work?<br><strong>A:</strong> Down 5th Street then over Maple; takes about ten minutes.</p><p><strong>Q:</strong> What did you do after arriving home?<br><strong>A:</strong> Made a sandwich and watched a game until the officers came.</p>
 </section>
-<section class='mt-2 page-break'>
+<section class='mt-2'>
 <h2>Officer Notes</h2>
-<p>Interview conducted 2023-11-06 09:00 by Det. Morin and Sgt. Dupuis. Subject calm, provided work timesheet verifying alibi.</p>
+<p>Interview conducted 2023-11-06 09:00 by Det. Morin and Sgt. Dupuis. Subject calm, provided work timesheet verifying alibi. Clarke maintained eye contact but hesitated when asked about missing locket. No visible injuries or signs of recent altercation were observed.</p>
 </section>
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>PHONE RECORDS</h1>
@@ -162,16 +155,14 @@
 
 <section class='mt-2'>
 <h2>Call Detail Records</h2>
-<table class='table'><thead><tr><th>Timestamp</th><th>Dir</th><th>Counterpart</th><th>Duration</th><th>Cell/Site</th></tr></thead><tbody><tr><td>20:55</td><td>Out</td><td>Voicemail</td><td>00:00</td><td>Tower 17</td></tr><tr><td>21:02</td><td>In</td><td>Marina Hale</td><td>00:45</td><td>Tower 12</td></tr><tr><td>21:45</td><td>Out</td><td>911</td><td>00:30</td><td>Tower 12</td></tr></tbody></table>
+<table class='table'><thead><tr><th>Timestamp</th><th>Dir</th><th>Counterpart</th><th>Duration</th><th>Cell/Site</th></tr></thead><tbody><tr><td>19:30</td><td>Out</td><td>Pizza Palace</td><td>00:02</td><td>Tower 7</td></tr><tr><td>19:47</td><td>In</td><td>Unknown</td><td>00:01</td><td>Tower 7</td></tr><tr><td>20:55</td><td>Out</td><td>Voicemail</td><td>00:00</td><td>Tower 17</td></tr><tr><td>21:02</td><td>In</td><td>Marina Hale</td><td>00:45</td><td>Tower 12</td></tr><tr><td>21:45</td><td>Out</td><td>911</td><td>00:30</td><td>Tower 12</td></tr><tr><td>22:15</td><td>In</td><td>Mother</td><td>00:05</td><td>Tower 12</td></tr></tbody></table>
 <p>Note: 21:02 incoming call from Marina Hale routes through Tower 12 although accused resides near Tower 7, indicating phone left elsewhere.</p>
 </section>
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>EMAIL RECORDS</h1>
@@ -197,10 +188,8 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>AUTOPSY REPORT</h1>
@@ -220,24 +209,25 @@
 
 <section class='mt-2'>
 <h2>External Examination</h2>
-<p>Body of Lena Roussel, apparent age 29, 165 cm, 60 kg. Lividity posterior, fixed. Notable contusion on left temple.</p>
+<p>Body of Lena Roussel, apparent age 29, 165 cm, 60 kg. Lividity posterior, fixed. Notable contusion on left temple and minor abrasions on forearms.</p>
 </section>
 <section class='mt-2'>
 <h2>Internal Examination</h2>
-<p>Cranial cavity reveals subdural hemorrhage. No defensive wounds on hands. Stomach contents indicate recent meal.</p>
+<p>Cranial cavity reveals subdural hemorrhage. No defensive wounds on hands. Stomach contents indicate recent meal of pasta; heart free of disease.</p>
+</section>
+<section class='mt-2'>
+<h2>Time of Death</h2>
+<p>Estimated time of death is 20:50 ±15 minutes based on body temperature and lividity.</p>
 </section>
 <section class='mt-2'>
 <h2>Cause and Manner</h2>
-<p>Cause of death: blunt force trauma to head. Manner: undetermined pending investigation.</p>
+<p>Cause of death: blunt force trauma to head. Manner: undetermined pending investigation. No evidence of intoxicants at lethal levels.</p>
 </section>
-<section class='page-break'></section>
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>TOXICOLOGY REPORT</h1>
@@ -262,10 +252,8 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>CHAIN OF CUSTODY</h1>
@@ -290,10 +278,9 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
+
 <article class='doc'>
 <section class='doc-header'>
 <h1>SEARCH WARRANT & RETURN</h1>
@@ -314,17 +301,15 @@
 <section class='mt-2'>
 <h2>Search Warrant</h2>
 <p>Magistrate hereby authorizes search of Nathan Clarke's residence for items related to the homicide of Lena Roussel. Items seized include phone records and clothing.</p>
-<div class='page-break'></div>
 <h2>Return Inventory</h2>
 <ul><li>Silver locket with initials L.R.</li><li>Burner phone left on kitchen counter</li></ul>
 </section>
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
+
 <article class='doc'>
 <section class='doc-header'>
 <h1>CRIME SCENE LOG</h1>
@@ -350,9 +335,7 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 </body>
 </html>

--- a/casekit/case-01/supplementary-records.html
+++ b/casekit/case-01/supplementary-records.html
@@ -33,10 +33,9 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
+
 <article class='doc'>
 <section class='doc-header'>
 <h1>LETTERS</h1>
@@ -62,10 +61,9 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
+
 <article class='doc'>
 <section class='doc-header'>
 <h1>SOCIAL MEDIA POSTS</h1>
@@ -90,9 +88,7 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 </body>
 </html>

--- a/casekit/case-02/police-records.html
+++ b/casekit/case-02/police-records.html
@@ -28,15 +28,15 @@
 
 <section class='mt-2'>
 <h2>Summary</h2>
-<p>On 2024-01-18 at approximately 21:13 hours, patrol units responded to a disturbance at 88 River Rd. Upon entry, officers located Rachael Singh unresponsive. The accused Nathan Clarke was not on scene. Initial observations noted signs of struggle and a silver locket near the body.</p>
+<p>On 2024-01-18 at approximately 21:13 hours, patrol units responded to a disturbance at 88 River Rd. Upon entry, officers located Rachael Singh unresponsive. The accused Nathan Clarke was not on scene. Initial observations noted signs of struggle, an overturned chair, and a silver locket near the body. The living room contained a broken picture frame and scattered mail suggesting a hurried search. Neighbors mentioned hearing the victim arguing with an unidentified caller roughly thirty minutes prior.</p>
 </section>
 <section class='mt-2'>
 <h2>Timeline</h2>
 <table class='table'><thead><tr><th>Time</th><th>Event</th><th>Ref</th></tr></thead><tbody><tr><td>21:13</td><td>911 call from neighbor reports disturbance</td><td>CR-LOG-02</td></tr><tr><td>21:40</td><td>Units arrive at 88 River Rd</td><td>IR-02-001</td></tr><tr><td>21:45</td><td>Victim Rachael Singh found deceased</td><td>E-Log-02</td></tr></tbody></table>
 </section>
-<section class='mt-2 page-break'>
+<section class='mt-2'>
 <h2>Officer Notes</h2>
-<p>Scene secured at 21:40. Weather clear, 5°C. Suspect vehicle not observed. A burner phone later linked to Nathan Clarke was recovered but records show no outgoing calls during critical window.</p>
+<p>Scene secured at 21:40. Weather clear, 5°C. Suspect vehicle not observed. A burner phone later linked to Nathan Clarke was recovered but records show no outgoing calls during critical window. Noted faint smell of bleach in kitchen, and a cup of coffee remained half full on the table. Officers canvassed alleyway behind residence and located fresh shoe prints leading toward River Road.</p>
 </section>
 <section class='mt-2'>
 <h2>Supplemental</h2>
@@ -45,10 +45,8 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>EVIDENCE LOG</h1>
@@ -73,10 +71,9 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
+
 <article class='doc'>
 <section class='doc-header'>
 <h1>WITNESS STATEMENTS</h1>
@@ -96,21 +93,19 @@
 
 <section class='mt-2'>
 <h2>Statement: Neighbor</h2>
-<p>I, Jenna Lee, residing at 88 River Rd Unit 2, state that around 21:10 I heard loud voices from Unit 1 followed by a thud. I saw a woman with dark hair hurriedly exit the building. She carried what looked like a tote bag.</p>
+<p>I, Jenna Lee, residing at 88 River Rd Unit 2, state that around 21:10 I heard loud voices from Unit 1 followed by a thud. I saw a woman with dark hair hurriedly exit the building. She carried what looked like a tote bag. I went back inside and continued watching television but kept the chain on the door.</p>
 <div class='sig-line'></div>
 </section>
-<section class='mt-2 page-break'>
+<section class='mt-2'>
 <h2>Statement: Accused</h2>
-<p>I, Nathan Clarke, state that I was at work until 22:30. My phone was left at home. I deny any involvement in the death of Rachael Singh. Marina Hale had been calling me repeatedly in the past weeks.</p>
+<p>I, Nathan Clarke, state that I was at work until 22:30. My phone was left at home. I deny any involvement in the death of Rachael Singh. Marina Hale had been calling me repeatedly in the past weeks. After my shift I stopped for coffee and chatted with the cashier about hockey scores before heading home.</p>
 <div class='sig-line'></div>
 </section>
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>INTERVIEW TRANSCRIPT</h1>
@@ -130,19 +125,17 @@
 
 <section class='mt-2'>
 <h2>Interview of Nathan Clarke</h2>
-<p><strong>Q:</strong> Where were you on 2024-01-18?<br><strong>A:</strong> I was covering shift at diner until 22:30.</p><p><strong>Q:</strong> Do you know Rachael Singh?<br><strong>A:</strong> She was a friend of Marina Hale.</p><p><strong>Q:</strong> Why was your locket at scene?<br><strong>A:</strong> I lost it weeks ago.</p>
+<p><strong>Q:</strong> Where were you on 2024-01-18?<br><strong>A:</strong> I was covering shift at diner until 22:30.</p><p><strong>Q:</strong> Do you know Rachael Singh?<br><strong>A:</strong> She was a friend of Marina Hale.</p><p><strong>Q:</strong> Why was your locket at scene?<br><strong>A:</strong> I lost it weeks ago.</p><p><strong>Q:</strong> Did you visit Rachael earlier that day?<br><strong>A:</strong> No, I stayed at the diner all afternoon.</p><p><strong>Q:</strong> What route do you take home from work?<br><strong>A:</strong> Down 5th Street then over Maple; takes about ten minutes.</p><p><strong>Q:</strong> What did you do after arriving home?<br><strong>A:</strong> Made a sandwich and watched a game until the officers came.</p>
 </section>
-<section class='mt-2 page-break'>
+<section class='mt-2'>
 <h2>Officer Notes</h2>
-<p>Interview conducted 2024-01-18 09:00 by Det. Morin and Sgt. Dupuis. Subject calm, provided work timesheet verifying alibi.</p>
+<p>Interview conducted 2024-01-18 09:00 by Det. Morin and Sgt. Dupuis. Subject calm, provided work timesheet verifying alibi. Clarke maintained eye contact but hesitated when asked about missing locket. No visible injuries or signs of recent altercation were observed.</p>
 </section>
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>PHONE RECORDS</h1>
@@ -162,16 +155,14 @@
 
 <section class='mt-2'>
 <h2>Call Detail Records</h2>
-<table class='table'><thead><tr><th>Timestamp</th><th>Dir</th><th>Counterpart</th><th>Duration</th><th>Cell/Site</th></tr></thead><tbody><tr><td>20:55</td><td>Out</td><td>Voicemail</td><td>00:00</td><td>Tower 17</td></tr><tr><td>21:02</td><td>In</td><td>Marina Hale</td><td>00:45</td><td>Tower 12</td></tr><tr><td>21:45</td><td>Out</td><td>911</td><td>00:30</td><td>Tower 12</td></tr></tbody></table>
+<table class='table'><thead><tr><th>Timestamp</th><th>Dir</th><th>Counterpart</th><th>Duration</th><th>Cell/Site</th></tr></thead><tbody><tr><td>19:30</td><td>Out</td><td>Pizza Palace</td><td>00:02</td><td>Tower 7</td></tr><tr><td>19:47</td><td>In</td><td>Unknown</td><td>00:01</td><td>Tower 7</td></tr><tr><td>20:55</td><td>Out</td><td>Voicemail</td><td>00:00</td><td>Tower 17</td></tr><tr><td>21:02</td><td>In</td><td>Marina Hale</td><td>00:45</td><td>Tower 12</td></tr><tr><td>21:45</td><td>Out</td><td>911</td><td>00:30</td><td>Tower 12</td></tr><tr><td>22:15</td><td>In</td><td>Mother</td><td>00:05</td><td>Tower 12</td></tr></tbody></table>
 <p>Note: 21:02 incoming call from Marina Hale routes through Tower 12 although accused resides near Tower 7, indicating phone left elsewhere.</p>
 </section>
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>EMAIL RECORDS</h1>
@@ -197,10 +188,8 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>AUTOPSY REPORT</h1>
@@ -220,24 +209,25 @@
 
 <section class='mt-2'>
 <h2>External Examination</h2>
-<p>Body of Rachael Singh, apparent age 29, 165 cm, 60 kg. Lividity posterior, fixed. Notable contusion on left temple.</p>
+<p>Body of Rachael Singh, apparent age 29, 165 cm, 60 kg. Lividity posterior, fixed. Notable contusion on left temple and minor abrasions on forearms.</p>
 </section>
 <section class='mt-2'>
 <h2>Internal Examination</h2>
-<p>Cranial cavity reveals subdural hemorrhage. No defensive wounds on hands. Stomach contents indicate recent meal.</p>
+<p>Cranial cavity reveals subdural hemorrhage. No defensive wounds on hands. Stomach contents indicate recent meal of pasta; heart free of disease.</p>
+</section>
+<section class='mt-2'>
+<h2>Time of Death</h2>
+<p>Estimated time of death is 20:50 ±15 minutes based on body temperature and lividity.</p>
 </section>
 <section class='mt-2'>
 <h2>Cause and Manner</h2>
-<p>Cause of death: blunt force trauma to head. Manner: undetermined pending investigation.</p>
+<p>Cause of death: blunt force trauma to head. Manner: undetermined pending investigation. No evidence of intoxicants at lethal levels.</p>
 </section>
-<section class='page-break'></section>
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>TOXICOLOGY REPORT</h1>
@@ -262,10 +252,8 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>CHAIN OF CUSTODY</h1>
@@ -290,10 +278,8 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>SEARCH WARRANT & RETURN</h1>
@@ -314,17 +300,15 @@
 <section class='mt-2'>
 <h2>Search Warrant</h2>
 <p>Magistrate hereby authorizes search of Nathan Clarke's residence for items related to the homicide of Rachael Singh. Items seized include phone records and clothing.</p>
-<div class='page-break'></div>
 <h2>Return Inventory</h2>
 <ul><li>Printed email threatening victim</li><li>Laptop with forged messages</li></ul>
 </section>
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
+
 <article class='doc'>
 <section class='doc-header'>
 <h1>CRIME SCENE LOG</h1>
@@ -350,9 +334,8 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
+
 </body>
 </html>

--- a/casekit/case-02/supplementary-records.html
+++ b/casekit/case-02/supplementary-records.html
@@ -33,10 +33,9 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
+
 <article class='doc'>
 <section class='doc-header'>
 <h1>LETTERS</h1>
@@ -62,10 +61,9 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
+
 <article class='doc'>
 <section class='doc-header'>
 <h1>SOCIAL MEDIA POSTS</h1>
@@ -90,9 +88,7 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 </body>
 </html>

--- a/casekit/case-03/police-records.html
+++ b/casekit/case-03/police-records.html
@@ -28,15 +28,15 @@
 
 <section class='mt-2'>
 <h2>Summary</h2>
-<p>On 2024-03-02 at approximately 21:13 hours, patrol units responded to a disturbance at 45 Lakeview Apt 5. Upon entry, officers located Marina Hale unresponsive. The accused Nathan Clarke was not on scene. Initial observations noted signs of struggle and a silver locket near the body.</p>
+<p>On 2024-03-02 at approximately 21:13 hours, patrol units responded to a disturbance at 45 Lakeview Apt 5. Upon entry, officers located Marina Hale unresponsive. The accused Nathan Clarke was not on scene. Initial observations noted signs of struggle, an overturned chair, and a silver locket near the body. The living room contained a broken picture frame and scattered mail suggesting a hurried search. Neighbors mentioned hearing the victim arguing with an unidentified caller roughly thirty minutes prior.</p>
 </section>
 <section class='mt-2'>
 <h2>Timeline</h2>
 <table class='table'><thead><tr><th>Time</th><th>Event</th><th>Ref</th></tr></thead><tbody><tr><td>21:13</td><td>911 call from neighbor reports disturbance</td><td>CR-LOG-03</td></tr><tr><td>21:40</td><td>Units arrive at 45 Lakeview Apt 5</td><td>IR-03-001</td></tr><tr><td>21:45</td><td>Victim Marina Hale found deceased</td><td>E-Log-03</td></tr></tbody></table>
 </section>
-<section class='mt-2 page-break'>
+<section class='mt-2'>
 <h2>Officer Notes</h2>
-<p>Scene secured at 21:40. Weather clear, 5°C. Suspect vehicle not observed. A burner phone later linked to Nathan Clarke was recovered but records show no outgoing calls during critical window.</p>
+<p>Scene secured at 21:40. Weather clear, 5°C. Suspect vehicle not observed. A burner phone later linked to Nathan Clarke was recovered but records show no outgoing calls during critical window. Noted faint smell of bleach in kitchen, and a cup of coffee remained half full on the table. Officers canvassed alleyway behind residence and located fresh shoe prints leading toward Lakeview Avenue.</p>
 </section>
 <section class='mt-2'>
 <h2>Supplemental</h2>
@@ -45,10 +45,8 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>EVIDENCE LOG</h1>
@@ -73,10 +71,10 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
+
 </section>
 </article>
-<div class="page-break"></div>
+
 <article class='doc'>
 <section class='doc-header'>
 <h1>WITNESS STATEMENTS</h1>
@@ -96,21 +94,19 @@
 
 <section class='mt-2'>
 <h2>Statement: Neighbor</h2>
-<p>I, Jenna Lee, residing at 45 Lakeview Apt 5 Unit 2, state that around 21:10 I heard loud voices from Unit 1 followed by a thud. I saw a woman with dark hair hurriedly exit the building. She carried what looked like a tote bag.</p>
+<p>I, Jenna Lee, residing at 45 Lakeview Apt 5 Unit 2, state that around 21:10 I heard loud voices from Unit 1 followed by a thud. I saw a woman with dark hair hurriedly exit the building. She carried what looked like a tote bag. I went back inside and continued watching television but kept the chain on the door.</p>
 <div class='sig-line'></div>
 </section>
-<section class='mt-2 page-break'>
+<section class='mt-2'>
 <h2>Statement: Accused</h2>
-<p>I, Nathan Clarke, state that I was at work until 22:30. My phone was left at home. I deny any involvement in the death of Marina Hale. Marina Hale had been calling me repeatedly in the past weeks.</p>
+<p>I, Nathan Clarke, state that I was at work until 22:30. My phone was left at home. I deny any involvement in the death of Marina Hale. Marina Hale had been calling me repeatedly in the past weeks. After my shift I stopped for coffee and chatted with the cashier about hockey scores before heading home.</p>
 <div class='sig-line'></div>
 </section>
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>INTERVIEW TRANSCRIPT</h1>
@@ -130,19 +126,17 @@
 
 <section class='mt-2'>
 <h2>Interview of Nathan Clarke</h2>
-<p><strong>Q:</strong> Where were you on 2024-03-02?<br><strong>A:</strong> I was covering shift at diner until 22:30.</p><p><strong>Q:</strong> Do you know Marina Hale?<br><strong>A:</strong> She was a friend of Marina Hale.</p><p><strong>Q:</strong> Why was your locket at scene?<br><strong>A:</strong> I lost it weeks ago.</p>
+<p><strong>Q:</strong> Where were you on 2024-03-02?<br><strong>A:</strong> I was covering shift at diner until 22:30.</p><p><strong>Q:</strong> Do you know Marina Hale?<br><strong>A:</strong> She was a friend of Marina Hale.</p><p><strong>Q:</strong> Why was your locket at scene?<br><strong>A:</strong> I lost it weeks ago.</p><p><strong>Q:</strong> Did you visit Marina earlier that day?<br><strong>A:</strong> No, I stayed at the diner all afternoon.</p><p><strong>Q:</strong> What route do you take home from work?<br><strong>A:</strong> Down 5th Street then over Maple; takes about ten minutes.</p><p><strong>Q:</strong> What did you do after arriving home?<br><strong>A:</strong> Made a sandwich and watched a game until the officers came.</p>
 </section>
-<section class='mt-2 page-break'>
+<section class='mt-2'>
 <h2>Officer Notes</h2>
-<p>Interview conducted 2024-03-02 09:00 by Det. Morin and Sgt. Dupuis. Subject calm, provided work timesheet verifying alibi.</p>
+<p>Interview conducted 2024-03-02 09:00 by Det. Morin and Sgt. Dupuis. Subject calm, provided work timesheet verifying alibi. Clarke maintained eye contact but hesitated when asked about missing locket. No visible injuries or signs of recent altercation were observed.</p>
 </section>
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>PHONE RECORDS</h1>
@@ -162,16 +156,14 @@
 
 <section class='mt-2'>
 <h2>Call Detail Records</h2>
-<table class='table'><thead><tr><th>Timestamp</th><th>Dir</th><th>Counterpart</th><th>Duration</th><th>Cell/Site</th></tr></thead><tbody><tr><td>20:55</td><td>Out</td><td>Voicemail</td><td>00:00</td><td>Tower 17</td></tr><tr><td>21:02</td><td>In</td><td>Marina Hale</td><td>00:45</td><td>Tower 12</td></tr><tr><td>21:45</td><td>Out</td><td>911</td><td>00:30</td><td>Tower 12</td></tr></tbody></table>
+<table class='table'><thead><tr><th>Timestamp</th><th>Dir</th><th>Counterpart</th><th>Duration</th><th>Cell/Site</th></tr></thead><tbody><tr><td>19:30</td><td>Out</td><td>Pizza Palace</td><td>00:02</td><td>Tower 7</td></tr><tr><td>19:47</td><td>In</td><td>Unknown</td><td>00:01</td><td>Tower 7</td></tr><tr><td>20:55</td><td>Out</td><td>Voicemail</td><td>00:00</td><td>Tower 17</td></tr><tr><td>21:02</td><td>In</td><td>Marina Hale</td><td>00:45</td><td>Tower 12</td></tr><tr><td>21:45</td><td>Out</td><td>911</td><td>00:30</td><td>Tower 12</td></tr><tr><td>22:15</td><td>In</td><td>Mother</td><td>00:05</td><td>Tower 12</td></tr></tbody></table>
 <p>Note: 21:02 incoming call from Marina Hale routes through Tower 12 although accused resides near Tower 7, indicating phone left elsewhere.</p>
 </section>
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>EMAIL RECORDS</h1>
@@ -197,10 +189,8 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>AUTOPSY REPORT</h1>
@@ -220,24 +210,25 @@
 
 <section class='mt-2'>
 <h2>External Examination</h2>
-<p>Body of Marina Hale, apparent age 29, 165 cm, 60 kg. Lividity posterior, fixed. Notable contusion on left temple.</p>
+<p>Body of Marina Hale, apparent age 29, 165 cm, 60 kg. Lividity posterior, fixed. Notable contusion on left temple and minor abrasions on forearms.</p>
 </section>
 <section class='mt-2'>
 <h2>Internal Examination</h2>
-<p>Cranial cavity reveals subdural hemorrhage. No defensive wounds on hands. Stomach contents indicate recent meal.</p>
+<p>Cranial cavity reveals subdural hemorrhage. No defensive wounds on hands. Stomach contents indicate recent meal of pasta; heart free of disease.</p>
+</section>
+<section class='mt-2'>
+<h2>Time of Death</h2>
+<p>Estimated time of death is 20:50 ±15 minutes based on body temperature and lividity.</p>
 </section>
 <section class='mt-2'>
 <h2>Cause and Manner</h2>
-<p>Cause of death: blunt force trauma to head. Manner: undetermined pending investigation.</p>
+<p>Cause of death: blunt force trauma to head. Manner: undetermined pending investigation. No evidence of intoxicants at lethal levels.</p>
 </section>
-<section class='page-break'></section>
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>TOXICOLOGY REPORT</h1>
@@ -262,10 +253,8 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 <article class='doc'>
 <section class='doc-header'>
 <h1>CHAIN OF CUSTODY</h1>
@@ -290,10 +279,10 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
+
 </section>
 </article>
-<div class="page-break"></div>
+
 <article class='doc'>
 <section class='doc-header'>
 <h1>SEARCH WARRANT & RETURN</h1>
@@ -314,17 +303,17 @@
 <section class='mt-2'>
 <h2>Search Warrant</h2>
 <p>Magistrate hereby authorizes search of Nathan Clarke's residence for items related to the homicide of Marina Hale. Items seized include phone records and clothing.</p>
-<div class='page-break'></div>
+
 <h2>Return Inventory</h2>
 <ul><li>Rope segment from ceiling beam</li><li>Note fragments in trash</li></ul>
 </section>
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
+
 </section>
 </article>
-<div class="page-break"></div>
+
 <article class='doc'>
 <section class='doc-header'>
 <h1>CRIME SCENE LOG</h1>
@@ -350,9 +339,9 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
+
 </section>
 </article>
-<div class="page-break"></div>
+
 </body>
 </html>

--- a/casekit/case-03/supplementary-records.html
+++ b/casekit/case-03/supplementary-records.html
@@ -33,10 +33,9 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
+
 <article class='doc'>
 <section class='doc-header'>
 <h1>LETTERS</h1>
@@ -62,10 +61,9 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
+
 <article class='doc'>
 <section class='doc-header'>
 <h1>SOCIAL MEDIA POSTS</h1>
@@ -90,9 +88,7 @@
 
 <section class='doc-footer'>
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
-<div>Page ___ of ___</div>
 </section>
 </article>
-<div class="page-break"></div>
 </body>
 </html>

--- a/casekit/styles/base.css
+++ b/casekit/styles/base.css
@@ -25,6 +25,7 @@ h1 { text-transform:uppercase; letter-spacing:.04em; }
 .mono { font-family:"Courier New", Courier, monospace; }
 .box { border:1px solid var(--line); padding:8px; border-radius:2px; }
 .doc { page-break-after:always; position:relative; padding:16px; margin:16px auto; max-width:8.5in; background:#fff; }
+.doc:last-of-type { page-break-after:auto; }
 .doc-header { padding-bottom:8px; border-bottom:2px solid var(--accent); margin-bottom:12px; }
 .doc-footer { padding-top:8px; border-top:1px solid var(--line); margin-top:16px; }
 .rule { height:2px; background:var(--accent); margin:6px 0 12px; }
@@ -35,4 +36,3 @@ h1 { text-transform:uppercase; letter-spacing:.04em; }
 .form .row { display:flex; margin-bottom:4px; }
 .form .label { width:30%; font-weight:bold; }
 .form .value { flex:1; }
-.page-break { page-break-after:always; }

--- a/casekit/styles/print.css
+++ b/casekit/styles/print.css
@@ -1,7 +1,7 @@
 @page { size: Letter; margin: 0.6in; }
 @media print {
   .doc { box-shadow:none; }
-  .page-break { page-break-after: always; }
+  .doc:last-of-type { page-break-after:auto; }
   header, footer { position: fixed; }
   .no-print { display:none !important; }
   * { -webkit-print-color-adjust: exact; print-color-adjust: exact; }


### PR DESCRIPTION
## Summary
- expand incident summaries, interviews, and officer notes across all case files
- extend call records and add estimated time of death to autopsy reports
- remove page number footers and streamline page breaks for printing

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ce761b4dc83249ee3a186a0b2d06d