### PR TITLE
Expand case supplementary records with misleading leads

### DIFF
--- a/casekit/case-01/supplementary-records.html
+++ b/casekit/case-01/supplementary-records.html
@@ -90,5 +90,59 @@
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
 </section>
 </article>
+
+<article class='doc'>
+<section class='doc-header'>
+<h1>WITNESS STATEMENT</h1>
+<div class='two-col'>
+<div>
+<div><strong>Agency:</strong> Brandon Police Service</div>
+<div><strong>Division:</strong> Major Crimes</div>
+<div><strong>Case #:</strong> 23-01157</div>
+</div>
+<div>
+<div><strong>Doc ID:</strong> WS-01-015</div>
+<div><strong>Prepared By:</strong> Det. K. Morin</div>
+<div><strong>Date:</strong> 2023-11-07</div>
+</div>
+</div>
+</section>
+
+<section class='mt-2'>
+<h2>Witness Statement</h2>
+<p>Neighbor Carla Mendez reported seeing a tall man in a black hoodie exiting the victim's building around 20:10. She believed it was maintenance worker Greg Taylor, though he denies being on site.</p>
+</section>
+
+<section class='doc-footer'>
+<div class='small muted'>Confidential — Law Enforcement Use Only</div>
+</section>
+</article>
+
+<article class='doc'>
+<section class='doc-header'>
+<h1>ANONYMOUS TIP</h1>
+<div class='two-col'>
+<div>
+<div><strong>Agency:</strong> Brandon Police Service</div>
+<div><strong>Division:</strong> Major Crimes</div>
+<div><strong>Case #:</strong> 23-01157</div>
+</div>
+<div>
+<div><strong>Doc ID:</strong> AT-01-016</div>
+<div><strong>Prepared By:</strong> Det. K. Morin</div>
+<div><strong>Date:</strong> 2023-11-08</div>
+</div>
+</div>
+</section>
+
+<section class='mt-2'>
+<h2>Anonymous Tip</h2>
+<p>An anonymous caller stated that Lena had been arguing with her landlord, Sylvia Benoit, over a rent increase and "said she would make her pay." Landlord alibi has not been verified.</p>
+</section>
+
+<section class='doc-footer'>
+<div class='small muted'>Confidential — Law Enforcement Use Only</div>
+</section>
+</article>
 </body>
 </html>

--- a/casekit/case-02/supplementary-records.html
+++ b/casekit/case-02/supplementary-records.html
@@ -90,5 +90,59 @@
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
 </section>
 </article>
+
+<article class='doc'>
+<section class='doc-header'>
+<h1>WITNESS STATEMENT</h1>
+<div class='two-col'>
+<div>
+<div><strong>Agency:</strong> Brandon Police Service</div>
+<div><strong>Division:</strong> Major Crimes</div>
+<div><strong>Case #:</strong> 23-01422</div>
+</div>
+<div>
+<div><strong>Doc ID:</strong> WS-02-015</div>
+<div><strong>Prepared By:</strong> Det. K. Morin</div>
+<div><strong>Date:</strong> 2024-01-19</div>
+</div>
+</div>
+</section>
+
+<section class='mt-2'>
+<h2>Witness Statement</h2>
+<p>Courier Aaron Chu reported a green sedan leaving the alley behind the victim's office at 19:20 with partial plate 8JP. He assumed it belonged to coworker Zoe Patel, though travel records show she was abroad.</p>
+</section>
+
+<section class='doc-footer'>
+<div class='small muted'>Confidential — Law Enforcement Use Only</div>
+</section>
+</article>
+
+<article class='doc'>
+<section class='doc-header'>
+<h1>ANONYMOUS TIP</h1>
+<div class='two-col'>
+<div>
+<div><strong>Agency:</strong> Brandon Police Service</div>
+<div><strong>Division:</strong> Major Crimes</div>
+<div><strong>Case #:</strong> 23-01422</div>
+</div>
+<div>
+<div><strong>Doc ID:</strong> AT-02-016</div>
+<div><strong>Prepared By:</strong> Det. K. Morin</div>
+<div><strong>Date:</strong> 2024-01-20</div>
+</div>
+</div>
+</section>
+
+<section class='mt-2'>
+<h2>Anonymous Tip</h2>
+<p>Blocked caller claimed Rachael owed money to local gambler Tony Vespa who "doesn't take no for an answer." Connection to case remains unverified.</p>
+</section>
+
+<section class='doc-footer'>
+<div class='small muted'>Confidential — Law Enforcement Use Only</div>
+</section>
+</article>
 </body>
 </html>

--- a/casekit/case-03/supplementary-records.html
+++ b/casekit/case-03/supplementary-records.html
@@ -90,5 +90,59 @@
 <div class='small muted'>Confidential — Law Enforcement Use Only</div>
 </section>
 </article>
+
+<article class='doc'>
+<section class='doc-header'>
+<h1>WITNESS STATEMENT</h1>
+<div class='two-col'>
+<div>
+<div><strong>Agency:</strong> Brandon Police Service</div>
+<div><strong>Division:</strong> Major Crimes</div>
+<div><strong>Case #:</strong> 23-01859</div>
+</div>
+<div>
+<div><strong>Doc ID:</strong> WS-03-015</div>
+<div><strong>Prepared By:</strong> Det. K. Morin</div>
+<div><strong>Date:</strong> 2024-03-03</div>
+</div>
+</div>
+</section>
+
+<section class='mt-2'>
+<h2>Witness Statement</h2>
+<p>Jogger Liam O'Connor observed a silver sedan with a broken left tail light near the park at 18:55. Vehicle registration traces to victim's ex-husband Daniel Hale, who reports the car was stolen.</p>
+</section>
+
+<section class='doc-footer'>
+<div class='small muted'>Confidential — Law Enforcement Use Only</div>
+</section>
+</article>
+
+<article class='doc'>
+<section class='doc-header'>
+<h1>ANONYMOUS TIP</h1>
+<div class='two-col'>
+<div>
+<div><strong>Agency:</strong> Brandon Police Service</div>
+<div><strong>Division:</strong> Major Crimes</div>
+<div><strong>Case #:</strong> 23-01859</div>
+</div>
+<div>
+<div><strong>Doc ID:</strong> AT-03-016</div>
+<div><strong>Prepared By:</strong> Det. K. Morin</div>
+<div><strong>Date:</strong> 2024-03-04</div>
+</div>
+</div>
+</section>
+
+<section class='mt-2'>
+<h2>Anonymous Tip</h2>
+<p>An anonymous email alleged Marina planned to expose company fraud orchestrated by CFO Lara Benson. Benson denies involvement; audit pending.</p>
+</section>
+
+<section class='doc-footer'>
+<div class='small muted'>Confidential — Law Enforcement Use Only</div>
+</section>
+</article>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add witness statements to each case's supplementary records for extra investigative detail
- include anonymous tips that introduce red-herring suspects

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cf69c9fc48324b07fe2f8fb26c7b6